### PR TITLE
xen_arm: Retrieve PCI host bridge resources from Xenstore

### DIFF
--- a/hw/arm/xen_arm.c
+++ b/hw/arm/xen_arm.c
@@ -22,6 +22,7 @@
  */
 
 #include "qemu/osdep.h"
+#include "qemu/cutils.h"
 #include "qemu/error-report.h"
 #include "qapi/qapi-commands-migration.h"
 #include "hw/boards.h"
@@ -74,16 +75,16 @@ static MemoryRegion ram_lo, ram_hi;
 #define NR_VIRTIO_MMIO_DEVICES   \
    (GUEST_VIRTIO_MMIO_SPI_LAST - GUEST_VIRTIO_MMIO_SPI_FIRST)
 
-static const MemMapEntry xen_memmap[] = {
+static MemMapEntry xen_memmap[] = {
     [VIRTIO_MMIO_IDX]     = { GUEST_VIRTIO_MMIO_BASE, VIRTIO_MMIO_DEV_SIZE },
-    [VIRT_PCIE_MMIO]      = { GUEST_VPCI_MEM_ADDR, GUEST_VPCI_MEM_SIZE },
-    [VIRT_PCIE_ECAM]      = { GUEST_VPCI_ECAM_BASE, GUEST_VPCI_ECAM_SIZE },
-    [VIRT_PCIE_MMIO_HIGH] = { GUEST_VPCI_PREFETCH_MEM_ADDR, GUEST_VPCI_PREFETCH_MEM_SIZE },
+    [VIRT_PCIE_MMIO]      = { 0 },
+    [VIRT_PCIE_ECAM]      = { 0 },
+    [VIRT_PCIE_MMIO_HIGH] = { 0 },
 };
 
-static const int xen_irqmap[] = {
+static int xen_irqmap[] = {
     [VIRTIO_MMIO_IDX] = GUEST_VIRTIO_MMIO_SPI_FIRST, /* ...to GUEST_VIRTIO_MMIO_SPI_LAST - 1 */
-    [VIRT_PCIE]       = GUEST_VIRTIO_PCI_SPI_FIRST,  /* ...to GUEST_VIRTIO_PCI_SPI_LAST - 1 */
+    [VIRT_PCIE]       = 0,
 };
 
 /* TODO It should be xendevicemodel_set_pci_intx_level() for PCI interrupts. */
@@ -193,6 +194,140 @@ static void xen_create_pcie(XenArmState *xam)
     DPRINTF("Created PCIe host bridge\n");
 }
 
+static int xen_get_pcie_params(XenArmState *xam)
+{
+    char path[128], *value = NULL, **entries = NULL;
+    unsigned int len, tmp;
+    int rc = -1;
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host",
+             xen_domid);
+    entries = xs_directory(xam->state->xenstore, XBT_NULL, path, &len);
+    if (entries == NULL) {
+        error_report("xenpv: 'virtio_pci_host' dir is not present");
+        return -1;
+    }
+    free(entries);
+    if (len != 9) {
+        error_report("xenpv: Unexpected num of entries in 'virtio_pci_host' dir");
+        goto out;
+    }
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/id",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtoui(value, NULL, 10, &tmp)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/id' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    if (tmp > 0xffff) {
+        error_report("xenpv: Wrong 'virtio_pci_host/id' value %u", tmp);
+        goto out;
+    }
+    xen_pci_segment = tmp;
+    DPRINTF("PCIe host bridge: id (xen_pci_segment) %u\n", xen_pci_segment);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/ecam_base",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtou64(value, NULL, 16, &xen_memmap[VIRT_PCIE_ECAM].base)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/ecam_base' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: ecam_base 0x%lx\n", xen_memmap[VIRT_PCIE_ECAM].base);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/ecam_size",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtou64(value, NULL, 16, &xen_memmap[VIRT_PCIE_ECAM].size)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/ecam_size' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: ecam_size 0x%lx\n", xen_memmap[VIRT_PCIE_ECAM].size);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/mem_base",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtou64(value, NULL, 16, &xen_memmap[VIRT_PCIE_MMIO].base)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/mem_base' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: mem_base 0x%lx\n", xen_memmap[VIRT_PCIE_MMIO].base);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/mem_size",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtou64(value, NULL, 16, &xen_memmap[VIRT_PCIE_MMIO].size)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/mem_size' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: mem_size 0x%lx\n", xen_memmap[VIRT_PCIE_MMIO].size);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/prefetch_mem_base",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtou64(value, NULL, 16, &xen_memmap[VIRT_PCIE_MMIO_HIGH].base)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/prefetch_mem_base' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: prefetch_mem_base 0x%lx\n", xen_memmap[VIRT_PCIE_MMIO_HIGH].base);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/prefetch_mem_size",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtou64(value, NULL, 16, &xen_memmap[VIRT_PCIE_MMIO_HIGH].size)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/prefetch_mem_size' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: prefetch_mem_size 0x%lx\n", xen_memmap[VIRT_PCIE_MMIO_HIGH].size);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/irq_first",
+             xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtoi(value, NULL, 10, &xen_irqmap[VIRT_PCIE])) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/irq_first' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    DPRINTF("PCIe host bridge: irq_first %u\n", xen_irqmap[VIRT_PCIE]);
+
+    snprintf(path, sizeof(path), "device-model/%d/virtio_pci_host/num_irqs", xen_domid);
+    value = xs_read(xam->state->xenstore, XBT_NULL, path, &len);
+    if (qemu_strtoui(value, NULL, 10, &tmp)) {
+        error_report("xenpv: Failed to get 'virtio_pci_host/num_irqs' prop");
+        goto out;
+    }
+    free(value);
+    value = NULL;
+    if (tmp != GPEX_NUM_IRQS) {
+        error_report("xenpv: Wrong 'virtio_pci_host/num_irqs' value %u", tmp);
+        goto out;
+    }
+    DPRINTF("PCIe host bridge: num_irqs %u\n", tmp);
+
+    rc = 0;
+out:
+    if (value)
+        free(value);
+
+    return rc;
+}
+
 void arch_handle_ioreq(XenIOState *state, ioreq_t *req)
 {
     hw_error("Invalid ioreq type 0x%x\n", req->type);
@@ -263,7 +398,10 @@ static void xen_arm_init(MachineState *machine)
 
     xen_init_ram(machine);
     xen_create_virtio_mmio_devices(xam);
-    xen_create_pcie(xam);
+    if (!xen_get_pcie_params(xam))
+        xen_create_pcie(xam);
+    else
+        DPRINTF("PCIe host bridge is not available, only virtio-mmio can be used\n");
 
     xen_enable_tpm();
 

--- a/hw/xen/xen-hvm-common.c
+++ b/hw/xen/xen-hvm-common.c
@@ -24,6 +24,8 @@ DeviceListener xen_device_listener = {
     .unrealize = xen_device_unrealize,
 };
 
+uint16_t xen_pci_segment = 0;
+
 static void xen_set_memory(struct MemoryListener *listener,
                            MemoryRegionSection *section,
                            bool add)
@@ -346,7 +348,12 @@ static void cpu_ioreq_config(XenIOState *state, ioreq_t *req)
     }
 
     QLIST_FOREACH(xendev, &state->dev_list, entry) {
-        if (xendev->sbdf != sbdf) {
+        /*
+         * As we append xen_pci_segment just before forming dm_op in
+         * xen_map_pcidev() we need to check with appended xen_pci_segment
+         * here as well.
+         */
+        if ((xendev->sbdf | (xen_pci_segment << 16)) != sbdf) {
             continue;
         }
 

--- a/include/hw/xen/xen_common.h
+++ b/include/hw/xen/xen_common.h
@@ -574,6 +574,8 @@ static inline void xen_unmap_io_section(domid_t dom,
                                                     0, start_addr, end_addr);
 }
 
+extern uint16_t xen_pci_segment;
+
 static inline void xen_map_pcidev(domid_t dom,
                                   ioservid_t ioservid,
                                   PCIDevice *pci_dev)
@@ -584,7 +586,8 @@ static inline void xen_map_pcidev(domid_t dom,
 
     trace_xen_map_pcidev(ioservid, pci_dev_bus_num(pci_dev),
                          PCI_SLOT(pci_dev->devfn), PCI_FUNC(pci_dev->devfn));
-    xendevicemodel_map_pcidev_to_ioreq_server(xen_dmod, dom, ioservid, 0,
+    xendevicemodel_map_pcidev_to_ioreq_server(xen_dmod, dom, ioservid,
+                                              xen_pci_segment,
                                               pci_dev_bus_num(pci_dev),
                                               PCI_SLOT(pci_dev->devfn),
                                               PCI_FUNC(pci_dev->devfn));
@@ -600,7 +603,8 @@ static inline void xen_unmap_pcidev(domid_t dom,
 
     trace_xen_unmap_pcidev(ioservid, pci_dev_bus_num(pci_dev),
                            PCI_SLOT(pci_dev->devfn), PCI_FUNC(pci_dev->devfn));
-    xendevicemodel_unmap_pcidev_from_ioreq_server(xen_dmod, dom, ioservid, 0,
+    xendevicemodel_unmap_pcidev_from_ioreq_server(xen_dmod, dom, ioservid,
+                                                  xen_pci_segment,
                                                   pci_dev_bus_num(pci_dev),
                                                   PCI_SLOT(pci_dev->devfn),
                                                   PCI_FUNC(pci_dev->devfn));


### PR DESCRIPTION
We cannot rely on the static vPCI resources anymore for virtio-pci due to several reasons:
- We updated Xen to not reuse vPCI resources for the virtio-pci, for the later we reserved separate resources.
- The guest memory layout that describes these resources is not stable and may vary between guests, so we cannot rely on static resources to be always the same for both ends.
- Also the device-models which run in different domains and serve virtio-pci devices for the same guest should use different host bridge resources for Xen to distinguish. The rule for the guest device-tree generation is one PCI host bridge per backend domain.