### PR TITLE
Fix domain reboot/destruction

### DIFF
--- a/hw/xen/xen-mapcache.c
+++ b/hw/xen/xen-mapcache.c
@@ -132,22 +132,18 @@ static MapCache *xen_map_cache_init_single(phys_offset_to_gaddr_t f,
     return mc;
 }
 
+#define DEFAULT_BUCKET_SHIFT 16U
+
 void xen_map_cache_init(phys_offset_to_gaddr_t f, void *opaque)
 {
     struct rlimit rlimit_as;
     unsigned long max_mcache_size;
-    unsigned int bucket_shift;
+    unsigned int bucket_shift = DEFAULT_BUCKET_SHIFT;
 
     xen_region_gnttabdev = xengnttab_open(NULL, 0);
     if (xen_region_gnttabdev == NULL) {
         error_report("mapcache: Failed to open gnttab device");
         exit(EXIT_FAILURE);
-    }
-
-    if (HOST_LONG_BITS == 32) {
-        bucket_shift = 16;
-    } else {
-        bucket_shift = 20;
     }
 
     if (geteuid() == 0) {

--- a/hw/xen/xen-mapcache.c
+++ b/hw/xen/xen-mapcache.c
@@ -582,11 +582,10 @@ static void xen_invalidate_map_cache_entry_unlocked(MapCache *mc,
         return;
     }
     entry->lock--;
-    if (entry->lock > 0 || pentry == NULL) {
+    if (entry->lock > 0) {
         return;
     }
 
-    pentry->next = entry->next;
     ram_block_notify_remove(entry->vaddr_base, entry->size, entry->size);
     if (entry->flags & XEN_MAPCACHE_ENTRY_GRANT) {
         rc = xengnttab_unmap(xen_region_gnttabdev, entry->vaddr_base,
@@ -601,7 +600,22 @@ static void xen_invalidate_map_cache_entry_unlocked(MapCache *mc,
     }
 
     g_free(entry->valid_mapping);
-    g_free(entry);
+    if (pentry) {
+        pentry->next = entry->next;
+        g_free(entry);
+    } else {
+        /*
+         * Invalidate mapping but keep entry->next pointing to the rest
+         * of the list.
+         *
+         * Note that lock is already zero here, otherwise we don't unmap.
+         */
+        entry->paddr_index = 0;
+        entry->vaddr_base = NULL;
+        entry->valid_mapping = NULL;
+        entry->flags = 0;
+        entry->size = 0;
+    }
 }
 
 typedef struct XenMapCacheData {


### PR DESCRIPTION
The current implementation of QEMU includes a workaround that increases I/O bandwidth by leaving the first buckets in mapcache unmapped. However, this approach results in long-time domain destruction during intensive use of virtio-blk, which requires a large number of map/unmap operations. The proposed solution is to decrease the bucket size, which improves performance (please, see https://github.com/xen-troops/qemu/commit/7a855192e09b6dd913b38136ee0ad7c2d2f4b563 for details) for virtio and allows us to revert the previous workaround. Reverting W/A resolves the issue of long domain destruction times - for example, on Android, destruction previously took 2:30-3 min, but with these changes, it completes in about 3 sec.